### PR TITLE
Add an one-click setup and start script for Windows users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ git/
 model/
 outputs/
 __pycache__/
+.venv/
 
 test.py

--- a/webui-start.cmd
+++ b/webui-start.cmd
@@ -1,0 +1,21 @@
+@echo off
+cd /D "%~dp0"
+if exist .venv goto :start
+
+echo "Setup VENV"
+python -m venv .venv
+call .venv\Scripts\activate.bat
+
+echo "Install dependencies"
+pip install torch==1.13.1+cu117 torchvision==0.14.1+cu117 --extra-index-url https://download.pytorch.org/whl/cu117
+pip install --upgrade -r requirements.txt
+goto :run
+
+:start
+echo "Start VENV"
+call .venv\Scripts\activate.bat
+goto :run
+
+:run
+echo "Start WebUI"
+python webui.py


### PR DESCRIPTION
This change adds a one-click "setup and run" script for Windows users that...

 * Sets up VENV if necessary
 * Installs dependencies if necessary
 * Starts the webui in the VENV

Partially resolves #21.