### PR TITLE
Fix: optimize model selection logic to avoid cuda out of memory error.

### DIFF
--- a/modules/options.py
+++ b/modules/options.py
@@ -4,7 +4,7 @@ parser = argparse.ArgumentParser()
 
 parser.add_argument("--port", type=int, default="17860")
 parser.add_argument("--model-path", type=str, default="THUDM/chatglm-6b")
-parser.add_argument("--precision", type=str, help="evaluate at this precision", choices=["fp32", "fp16", "int4", "int8"], default="fp16")
+parser.add_argument("--precision", type=str, help="evaluate at this precision", choices=["fp32", "fp16", "int4", "int8"])
 parser.add_argument("--listen", action='store_true', help="launch gradio with 0.0.0.0 as server name, allowing to respond to network requests")
 parser.add_argument("--cpu", action='store_true', help="use cpu")
 parser.add_argument("--share", action='store_true', help="use gradio share")


### PR DESCRIPTION
## 概述
小小的优化一下，我刚刚用的时候爆显存了hhh。

使用torch库自动检测显存大小。
应该可以有效解决小显存用户会运行的时候默认使用`fp16`然后报`RuntimeError: CUDA out of memory`的问题

关于precision参数是怎么决定的参考的[这里](https://github.com/THUDM/ChatGLM-6B#%E7%A1%AC%E4%BB%B6%E9%9C%80%E6%B1%82)

## 测试结果
```
Explicitly passing a `revision` is encouraged when loading a model with custom code to ensure no malicious code has been contributed in a newer revision.
Explicitly passing a `revision` is encouraged when loading a configuration with custom code to ensure no malicious code has been contributed in a newer revision.
Explicitly passing a `revision` is encouraged when loading a model with custom code to ensure no malicious code has been contributed in a newer revision.
Loading checkpoint shards: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [00:13<00:00,  1.65s/it]
GPU memory: 10.74 GB
Choosing precision int8 according to your VRAM. If you want to decide precision yourself, please add argument --precision when launching the application.
Running on local URL:  http://127.0.0.1:17860

To create a public link, set `share=True` in `launch()`.

```