### PR TITLE
防止使用webui-start时出现该错误 'Library cudart is not initialized'

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -6,7 +6,7 @@ from modules.model import load_model
 
 from modules.options import cmd_opts
 from modules.ui import create_ui
-
+os.environ['PATH'] = os.environ.get("PATH", "") + os.pathsep + os.getcwd() + r'\.venv\Lib\site-packages\torch\lib'
 
 def ensure_output_dirs():
     folders = ["outputs/save", "outputs/markdown"]


### PR DESCRIPTION
Generation failed: RuntimeError('Library cudart is not initialized')