### PR TITLE
优化一些模型下载问题

### DIFF
--- a/modules/model.py
+++ b/modules/model.py
@@ -1,3 +1,4 @@
+import os
 from typing import Optional, List, Tuple
 
 from torch.cuda import get_device_properties
@@ -49,6 +50,9 @@ def prepare_model():
 
 
 def load_model():
+    path = os.getcwd()
+    os.chdir(path + '/modules/')
+
     if cmd_opts.ui_dev:
         return
 
@@ -58,6 +62,9 @@ def load_model():
 
     tokenizer = AutoTokenizer.from_pretrained(cmd_opts.model_path, trust_remote_code=True)
     model = AutoModel.from_pretrained(cmd_opts.model_path, trust_remote_code=True)
+    
+    os.chdir(path)
+
     prepare_model()
 
 

--- a/modules/options.py
+++ b/modules/options.py
@@ -3,7 +3,7 @@ import argparse
 parser = argparse.ArgumentParser()
 
 parser.add_argument("--port", type=int, default="17860")
-parser.add_argument("--model-path", type=str, default="THUDM/chatglm-6b")
+parser.add_argument("--model-path", default="ChatGLM-6B")
 parser.add_argument("--precision", type=str, help="evaluate at this precision", choices=["fp32", "fp16", "int4", "int8"])
 parser.add_argument("--listen", action='store_true', help="launch gradio with 0.0.0.0 as server name, allowing to respond to network requests")
 parser.add_argument("--cpu", action='store_true', help="use cpu")

--- a/webui-start.cmd
+++ b/webui-start.cmd
@@ -1,4 +1,6 @@
 @echo off
+git lfs install
+git lfs clone https://huggingface.co/THUDM/chatglm-6b %cd%\modules\chatglm-6b\
 cd /D "%~dp0"
 if exist .venv goto :start
 


### PR DESCRIPTION
Optimize the model download, download the model directly to the '\modules\chatglm-6b\' directory, no need to put in C disk, avoid self-check. But there may be bugs？