### PR TITLE
feat: add path-prefix cli options

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,5 @@ python webui.py
 `--precision`: fp32(CPU only), fp16, int4(CUDA GPU only), int8(CUDA GPU only)
 
 `--cpu`: use cpu
+
+`--path-prefix`: url root path. If this parameter is not specified manually, the default value is `/`. Using a path prefix of `/foo/bar` enables ChatGLM-webui to serve from `http://$ip:$port/foo/bar/` rather than `http://$ip:$port/`.

--- a/modules/options.py
+++ b/modules/options.py
@@ -10,6 +10,7 @@ parser.add_argument("--cpu", action='store_true', help="use cpu")
 parser.add_argument("--share", action='store_true', help="use gradio share")
 parser.add_argument("--device-id", type=str, help="select the default CUDA device to use", default=None)
 parser.add_argument("--ui-dev", action='store_true', help="ui develop mode", default=None)
+parser.add_argument("--path-prefix", type=str, help="url root path, e.g. /app", default='/')
 
 cmd_opts = parser.parse_args()
 need_restart = False

--- a/webui.py
+++ b/webui.py
@@ -46,7 +46,8 @@ def main():
             server_name="0.0.0.0" if cmd_opts.listen else None,
             server_port=cmd_opts.port,
             share=cmd_opts.share,
-            prevent_thread_lock=True
+            prevent_thread_lock=True,
+            root_path=cmd_opts.path_prefix,
         )
         wait_on_server(ui)
         print('Restarting UI...')


### PR DESCRIPTION
### Why we need `path-prefix`(or `root-path`)?
The root path (or "mount point") of the application, if it's not served from the root ("/") of the domain. Often used when the application is behind a reverse proxy that forwards requests to the application. For example, if the application is served at "https://example.com/myapp", the `root_path` should be set to "/myapp".
### Why is it named `path-prefix`?
Refer to the naming of the tensorboard's cli args.
https://github.com/tensorflow/tensorboard/blob/master/tensorboard/backend/path_prefix.py#L17